### PR TITLE
[TestGen] Add API and UI tests for data verification

### DIFF
--- a/ApiTests/DataApiTests.cs
+++ b/ApiTests/DataApiTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class DataApiTests
+    {
+        private IAPIRequestContext _apiContext;
+
+        [SetUp]
+        public void Setup()
+        {
+            var playwright = Playwright.CreateAsync().Result;
+            _apiContext = playwright.APIRequest.NewContextAsync().Result;
+        }
+
+        [Test]
+        public async Task PostData_ShouldReturnSuccess()
+        {
+            // Arrange
+            var payload = new { name = "Test Item " + Guid.NewGuid() };
+            var options = new APIRequestContextOptions
+            {
+                ContentType = "application/json",
+                Data = JsonSerializer.Serialize(payload)
+            };
+
+            // Act
+            var response = await _apiContext.PostAsync("http://localhost:5000/api/data", options);
+            var responseBody = await response.JsonAsync();
+
+            // Assert
+            Assert.AreEqual(201, response.Status);
+            Assert.IsTrue(responseBody.TryGetProperty("id", out _));
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty));
+            Assert.AreEqual(payload.name, nameProperty.GetString());
+
+            // Log
+            TestContext.WriteLine("Request Payload: " + JsonSerializer.Serialize(payload));
+            TestContext.WriteLine("Response Body: " + responseBody);
+        }
+
+        [Test]
+        public async Task GetData_ShouldReturnDataArray()
+        {
+            // Act
+            var response = await _apiContext.GetAsync("http://localhost:5000/api/data");
+            var responseBody = await response.JsonAsync();
+
+            // Assert
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(JsonValueKind.Array, responseBody.ValueKind);
+            Assert.IsTrue(responseBody[0].TryGetProperty("id", out _));
+            Assert.IsTrue(responseBody[0].TryGetProperty("name", out _));
+        }
+    }
+}

--- a/UiTests/DataUiTests.cs
+++ b/UiTests/DataUiTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace UiTests
+{
+    [TestFixture]
+    public class DataUiTests : UiTestBase
+    {
+        [Test]
+        public async Task CreatedItem_ShouldBeVisibleInUI()
+        {
+            // Arrange
+            var payload = new { name = "Test Item " + Guid.NewGuid() };
+            var options = new APIRequestContextOptions
+            {
+                ContentType = "application/json",
+                Data = JsonSerializer.Serialize(payload)
+            };
+
+            var response = await ApiContext.PostAsync("http://localhost:5000/api/data", options);
+            var responseBody = await response.JsonAsync();
+            var itemId = responseBody.GetProperty("id").GetString();
+
+            // Act
+            await Page.GotoAsync("http://localhost:5000");
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            var itemElement = await Page.QuerySelectorAsync(itemSelector);
+
+            // Assert
+            Assert.IsNotNull(itemElement);
+            Assert.IsTrue(await itemElement.IsVisibleAsync());
+            var innerText = await itemElement.InnerTextAsync();
+            Assert.IsTrue(innerText.Contains(payload.name));
+
+            // Highlight
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+
+            // Screenshot
+            var screenshotPath = System.IO.Path.Combine(TestContext.CurrentContext.WorkDirectory, $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following tests:

**API Tests**:
1. `PostData_ShouldReturnSuccess`
   - Verifies that a POST request to `/api/data` returns a successful response and contains the expected properties.
   - Logs the request payload and response body.

2. `GetData_ShouldReturnDataArray`
   - Verifies that a GET request to `/api/data` returns a status of 200 and the response is an array containing the expected keys.

**UI Tests**:
1. `CreatedItem_ShouldBeVisibleInUI`
   - Creates an item using the API and verifies that the created item is visible in the UI.
   - Asserts that the item is visible and its inner text contains the expected name.
   - Highlights the element and takes a full-page screenshot saved with a timestamped filename.

Test files:
- `ApiTests/DataApiTests.cs`
- `UiTests/DataUiTests.cs`