### PR TITLE
[TestGen] Add API and UI tests for verifyitem

### DIFF
--- a/ApiTests/DataItemApiTests.cs
+++ b/ApiTests/DataItemApiTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace ApiTests;
+
+[TestFixture]
+public class DataItemApiTests : UiTestBase
+{
+    [Test]
+    public async Task Test_PostDataItem()
+    {
+        // Arrange
+        var payload = new CreateDataItemRequest
+        {
+            Name = "Test Item " + Guid.NewGuid(),
+            Description = "Test Description"
+        };
+
+        var options = new APIRequestContextOptions
+        {
+            Headers = new Dictionary<string, string>
+            {
+                { "Content-Type", "application/json" }
+            },
+            Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            })
+        };
+
+        // Act
+        var response = await API.PostAsync("/api/data", options);
+        JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+        // Assert
+        Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+        Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty), "Response does not contain 'name'");
+        Assert.AreEqual(payload.Name, nameProperty.GetString(), "Name does not match");
+
+        TestContext.WriteLine("Request: " + JsonSerializer.Serialize(payload));
+        TestContext.WriteLine("Response: " + responseBody.ToString());
+    }
+
+    [Test]
+    public async Task Test_GetDataItems()
+    {
+        // Act
+        var response = await API.GetAsync("/api/data");
+        JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+        // Assert
+        Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array");
+        Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty");
+
+        TestContext.WriteLine("Response: " + responseBody.ToString());
+    }
+}

--- a/UiTests/DataItemUiTests.cs
+++ b/UiTests/DataItemUiTests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace UiTests;
+
+[TestFixture]
+public class DataItemUiTests : UiTestBase
+{
+    [Test]
+    public async Task Test_VerifyCreatedItemIsVisible()
+    {
+        // Arrange
+        var payload = new CreateDataItemRequest
+        {
+            Name = "Test Item " + Guid.NewGuid(),
+            Description = "Test Description"
+        };
+
+        var options = new APIRequestContextOptions
+        {
+            Headers = new Dictionary<string, string>
+            {
+                { "Content-Type", "application/json" }
+            },
+            Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            })
+        };
+
+        var postResponse = await API.PostAsync("/api/data", options);
+        JsonElement postResponseBody = (JsonElement)await postResponse.JsonAsync();
+
+        Assert.IsTrue(postResponseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+        var itemId = idProperty.GetInt32();
+
+        // Act
+        await Page.GotoAsync("http://localhost:5000");
+        var itemSelector = $"li[data-item-id='{itemId}']";
+        var item = await Page.QuerySelectorAsync(itemSelector);
+
+        // Assert
+        Assert.IsNotNull(item, "Item not found in the UI");
+        var itemName = await item.EvalOnSelectorAsync<string>("strong", "el => el.innerText");
+        Assert.AreEqual(payload.Name, itemName, "Item name does not match");
+
+        await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+        await Page.ScreenshotAsync(new PageScreenshotOptions { Path = "screenshot.png", FullPage = true });
+        TestContext.AddTestAttachment("screenshot.png");
+    }
+}


### PR DESCRIPTION
### Added Tests

- **API Tests**:
  - `ApiTests/DataItemApiTests.cs`
    - `Test_PostDataItem`: Verifies POST /api/data endpoint
    - `Test_GetDataItems`: Verifies GET /api/data endpoint

- **UI Tests**:
  - `UiTests/DataItemUiTests.cs`
    - `Test_VerifyCreatedItemIsVisible`: Verifies that the created item is visible in the UI

### Key Assertions
- API tests validate response structure and content.
- UI test ensures the item is visible and matches the expected name.
- Captures a screenshot and attaches it to the test context.