### PR TITLE
[TestGen] Add API and UI tests for verifyitem

### DIFF
--- a/ApiTests/DataApiTests.cs
+++ b/ApiTests/DataApiTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace ApiTests
+{
+    public class DataApiTests : UiTestBase
+    {
+        [Test]
+        public async Task PostDataItem_ShouldCreateNewItem()
+        {
+            // Arrange
+            var payload = new CreateDataItemRequest
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Test Description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty), "Response does not contain 'name'");
+            Assert.AreEqual(payload.Name, nameProperty.GetString(), "Name does not match");
+        }
+
+        [Test]
+        public async Task GetDataItems_ShouldReturnItems()
+        {
+            // Act
+            var response = await API.GetAsync("/api/data");
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty");
+        }
+    }
+}

--- a/UiTests/VerifyItemUiTests.cs
+++ b/UiTests/VerifyItemUiTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace UiTests
+{
+    public class VerifyItemUiTests : UiTestBase
+    {
+        [Test]
+        public async Task CreatedItem_ShouldBeVisibleInUI()
+        {
+            // Arrange
+            var payload = new CreateDataItemRequest
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Test Description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+            var itemId = idProperty.GetInt32();
+            var itemName = payload.Name;
+
+            // Act
+            await Page.GotoAsync("http://localhost:5000");
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            var itemElement = await Page.QuerySelectorAsync(itemSelector);
+
+            // Assert
+            TestContext.WriteLine($"🔍 Verifying item with selector: {itemSelector}");
+            Assert.IsNotNull(itemElement, "Item not found in UI");
+
+            var itemNameElement = await itemElement.QuerySelectorAsync("strong");
+            Assert.IsNotNull(itemNameElement, "Item name element not found");
+
+            var itemNameText = await itemNameElement.InnerTextAsync();
+            Assert.AreEqual(itemName, itemNameText, "Item name does not match");
+
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+            var screenshotPath = $"screenshot_{itemId}.png";
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}

--- a/UiTests/VerifyItemUiTests.cs
+++ b/UiTests/VerifyItemUiTests.cs
@@ -63,6 +63,7 @@ namespace UiTests
             await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
             var screenshotPath = $"screenshot_{itemId}.png";
             await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+TestContext.WriteLine($"📸 Screenshot captured: {screenshotPath}");
             TestContext.AddTestAttachment(screenshotPath);
         }
     }


### PR DESCRIPTION
### Added Tests

- **API Tests**: 
  - `PostDataItem_ShouldCreateNewItem` in `ApiTests/DataApiTests.cs`
  - `GetDataItems_ShouldReturnItems` in `ApiTests/DataApiTests.cs`
- **UI Test**: 
  - `CreatedItem_ShouldBeVisibleInUI` in `UiTests/VerifyItemUiTests.cs`

### Key Assertions
- API tests verify the creation and retrieval of data items.
- UI test verifies that the created item is visible in the UI and matches the expected name.
- Captures and attaches a screenshot of the UI with the highlighted item.

### Screenshot
- Full-page screenshot with the newly created item highlighted is attached in the UI test.
