### PR TITLE
[TestGen] Add API and UI tests for data item verification

### DIFF
--- a/ApiTests/DataItemApiTests.cs
+++ b/ApiTests/DataItemApiTests.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class DataItemApiTests : UiTestBase
+    {
+        [Test]
+        public async Task Test_PostDataItem()
+        {
+            // Arrange
+            var payload = new CreateDataItemRequest
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "This is a test description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+            Assert.IsTrue(idProperty.GetInt32() > 0, "Invalid 'id' value");
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty), "Response does not contain 'name'");
+            Assert.AreEqual(payload.Name, nameProperty.GetString(), "Name does not match");
+
+            // Log
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+
+        [Test]
+        public async Task Test_GetDataItems()
+        {
+            // Act
+            var response = await API.GetAsync("/api/data");
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty");
+
+            // Log
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+    }
+}

--- a/UiTests/DataItemUiTests.cs
+++ b/UiTests/DataItemUiTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace UiTests
+{
+    [TestFixture]
+    public class DataItemUiTests : UiTestBase
+    {
+        [Test]
+        public async Task Test_VerifyCreatedItemIsVisible()
+        {
+            // Arrange
+            var payload = new CreateDataItemRequest
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "This is a test description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+            var itemId = idProperty.GetInt32();
+
+            // Act
+            await Page.GotoAsync("http://localhost:5000");
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            TestContext.WriteLine($"🔍 Verifying item with selector: {itemSelector}");
+
+            var item = await Page.QuerySelectorAsync(itemSelector);
+            Assert.IsNotNull(item, "Item not found in the UI");
+
+            var itemName = await item.EvalOnSelectorAsync<string>("strong", "el => el.innerText");
+            Assert.AreEqual(payload.Name, itemName, "Item name does not match");
+
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+
+            var screenshotPath = $"screenshot_{itemId}.png";
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following tests:

- **API Tests**:
  - `Test_PostDataItem` in `ApiTests/DataItemApiTests.cs`: Verifies the `POST /api/data` endpoint.
  - `Test_GetDataItems` in `ApiTests/DataItemApiTests.cs`: Verifies the `GET /api/data` endpoint.

- **UI Test**:
  - `Test_VerifyCreatedItemIsVisible` in `UiTests/DataItemUiTests.cs`: Creates a data item via API and verifies its visibility in the UI.

Key assertions:
- API tests check for correct response structure and values.
- UI test checks for item visibility and name match, highlights the item, and captures a screenshot.

Screenshots are attached to the test context for UI tests.