### PR TITLE
[TestGen] Add API and UI tests for data verification

### DIFF
--- a/ApiTests/DataApiTests.cs
+++ b/ApiTests/DataApiTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+using System;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class DataApiTests : UiTestBase
+    {
+        [Test]
+        public async Task Test_PostData()
+        {
+            // Arrange
+            var payload = new CreateDataItemRequest
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "This is a test description."
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty), "Response does not contain 'name'");
+            Assert.AreEqual(payload.Name, nameProperty.GetString(), "Name does not match");
+
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+
+        [Test]
+        public async Task Test_GetData()
+        {
+            // Act
+            var response = await API.GetAsync("/api/data");
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty");
+
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+    }
+}

--- a/UiTests/DataUiTests.cs
+++ b/UiTests/DataUiTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+using System;
+using Microsoft.Playwright;
+
+namespace UiTests
+{
+    [TestFixture]
+    public class DataUiTests : UiTestBase
+    {
+        [Test]
+        public async Task Test_VerifyCreatedItemIsVisible()
+        {
+            // Arrange
+            var payload = new CreateDataItemRequest
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "This is a test description."
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+            var itemId = idProperty.GetInt32();
+
+            // Act
+            await Page.GotoAsync("http://localhost:5000");
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+
+            // Assert
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            var itemElement = await Page.QuerySelectorAsync(itemSelector);
+            Assert.IsNotNull(itemElement, $"Item with ID {itemId} not found in the UI");
+
+            var itemNameElement = await itemElement.QuerySelectorAsync("strong");
+            Assert.IsNotNull(itemNameElement, "Item name element not found");
+            var itemName = await itemNameElement.InnerTextAsync();
+            Assert.AreEqual(payload.Name, itemName, "Item name does not match");
+
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+            var screenshotPath = $"screenshot_{itemId}.png";
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following tests:

- **API Tests**:
  - `Test_PostData` in `ApiTests/DataApiTests.cs`: Verifies the POST `/api/data` endpoint.
  - `Test_GetData` in `ApiTests/DataApiTests.cs`: Verifies the GET `/api/data` endpoint.

- **UI Test**:
  - `Test_VerifyCreatedItemIsVisible` in `UiTests/DataUiTests.cs`: Verifies that a created item is visible in the UI.

Key assertions:
- API tests check for correct response structure and data.
- UI test checks for item visibility and correct name display.

Screenshots are captured and attached for UI tests.