### PR TITLE
[TestGen] Add UI and API tests for item creation

### DIFF
--- a/ApiTests/ApiTests.cs
+++ b/ApiTests/ApiTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using TestBase;
+
+namespace ApiTests;
+
+public class ApiTests : UiTestBase
+{
+    [Test]
+    public async Task Test_PostNewItem()
+    {
+        // Arrange
+        var newItem = new { name = "TestItem" };
+
+        // Act
+        var response = await API.PostAsync("/api/data", new JsonContent(newItem));
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.Created, response.Status);
+        var responseData = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        Assert.IsNotNull(responseData);
+        Assert.IsTrue(responseData.ContainsKey("id"));
+    }
+
+    [Test]
+    public async Task Test_GetItems()
+    {
+        // Act
+        var response = await API.GetAsync("/api/data");
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.Status);
+        var items = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+        Assert.IsNotNull(items);
+        Assert.IsNotEmpty(items);
+    }
+}

--- a/UiTests/UiTests.cs
+++ b/UiTests/UiTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+using TestBase;
+
+namespace UiTests;
+
+public class UiTests : UiTestBase
+{
+    [Test]
+    public async Task Test_VerifyNewItemInUI()
+    {
+        // Arrange
+        var newItem = new { name = "UITestItem" };
+        var response = await API.PostAsync("/api/data", new JsonContent(newItem));
+        var responseData = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var newItemId = responseData["id"].ToString();
+
+        // Act
+        await Page.GotoAsync("http://localhost:5000");
+        var listItem = Page.Locator($"li[data-item-id='{newItemId}']");
+
+        // Assert
+        Assert.IsTrue(await listItem.IsVisibleAsync());
+        var itemName = await listItem.Locator("strong").InnerTextAsync();
+        Assert.AreEqual("UITestItem", itemName);
+    }
+}


### PR DESCRIPTION
This PR adds new API and UI tests for verifying item creation.

**API Tests:**
1. `Test_PostNewItem`: Verifies that a new item can be created using the POST endpoint.
2. `Test_GetItems`: Verifies that the GET endpoint returns a list of items.

**UI Test:**
1. `Test_VerifyNewItemInUI`: Adds an item via the API and verifies that it appears in the UI.

All tests follow the Arrange → Act → Assert format and are designed to run with `dotnet test`.