### PR TITLE
[TestGen] Add API and UI tests for verifyitem

### DIFF
--- a/ApiTests/DataApiTests.cs
+++ b/ApiTests/DataApiTests.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class DataApiTests : UiTestBase
+    {
+        [Test]
+        public async Task PostData_ShouldCreateNewItem()
+        {
+            // Arrange
+            var payload = new {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Optional description"
+            };
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty), "Response does not contain 'name' property.");
+            Assert.AreEqual(payload.Name, nameProperty.GetString(), "Item name does not match.");
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id' property.");
+            Assert.Greater(idProperty.GetInt32(), 0, "Item ID should be greater than 0.");
+
+            // Log
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+
+        [Test]
+        public async Task GetData_ShouldReturnItems()
+        {
+            // Arrange
+
+            // Act
+            var response = await API.GetAsync("/api/data");
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array.");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty.");
+
+            // Log
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+    }
+}

--- a/ApiTests/GetDataTests.cs
+++ b/ApiTests/GetDataTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using TestBase;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class GetDataTests : UiTestBase
+    {
+        [Test]
+        public async Task GetData_ShouldReturnItemsArray()
+        {
+            // Arrange
+            // No setup required for GET request
+
+            // Act
+            var response = await API.GetAsync("/api/data");
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array.");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty.");
+
+            // Log
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+    }
+}

--- a/ApiTests/PostDataTests.cs
+++ b/ApiTests/PostDataTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class PostDataTests : UiTestBase
+    {
+        [Test]
+        public async Task PostData_ShouldCreateNewItem()
+        {
+            // Arrange
+            var payload = new {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Optional description"
+            };
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty), "Response does not contain 'name' property.");
+            Assert.AreEqual(payload.Name, nameProperty.GetString(), "Item name does not match.");
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id' property.");
+            Assert.Greater(idProperty.GetInt32(), 0, "Item ID is not valid.");
+
+            // Log
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+    }
+}

--- a/UiTests/VerifyItemUiTests.cs
+++ b/UiTests/VerifyItemUiTests.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace UiTests
+{
+    [TestFixture]
+    public class VerifyItemUiTests : UiTestBase
+    {
+        [Test]
+        public async Task CreatedItem_ShouldBeVisibleInUI()
+        {
+            // Arrange
+            var payload = new DataItem
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Optional description"
+            };
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+            var itemId = responseBody.GetProperty("id").GetInt32();
+
+            // Act
+            await Page.GotoAsync("http://localhost:5000");
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            var itemElement = await Page.QuerySelectorAsync(itemSelector);
+            TestContext.WriteLine($"🔍 Verifying item with selector: {itemSelector}");
+
+            // Assert
+            Assert.NotNull(itemElement, "Item element not found in UI.");
+            var itemName = await itemElement.EvalOnSelectorAsync("strong", "el => el.innerText");
+            Assert.AreEqual(payload.Name, itemName.ToString(), "Item name does not match.");
+
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+
+            var screenshotPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.WriteLine($"📸 Screenshot saved at: {screenshotPath}");
+            TestContext.WriteLine("✅ UI verification successful.");
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}

--- a/UiTests/VerifyItemVisibilityTests.cs
+++ b/UiTests/VerifyItemVisibilityTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+
+namespace UiTests
+{
+    [TestFixture]
+    public class VerifyItemVisibilityTests : UiTestBase
+    {
+        [Test]
+        public async Task VerifyItemVisibility_ShouldDisplayCreatedItem()
+        {
+            // Arrange
+            var payload = new {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Optional description"
+            };
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+            var itemId = responseBody.GetProperty("id").GetInt32();
+
+            // Log
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            // Act
+            await Page.GotoAsync("http://localhost:5000");
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            var itemElement = await Page.QuerySelectorAsync(itemSelector);
+
+            // Assert
+            Assert.NotNull(itemElement, "Item element not found in UI.");
+            var itemName = await itemElement.TextContentAsync();
+            Assert.IsTrue(itemName.Contains(payload.Name), "Item name does not match.");
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+
+            // Screenshot
+            var screenshotPath = System.IO.Path.Combine(TestContext.CurrentContext.WorkDirectory, $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.WriteLine($"📸 Screenshot saved at: {screenshotPath}");
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}


### PR DESCRIPTION
### Added Tests

- **API Tests**: `ApiTests/DataApiTests.cs`
  - `PostData_ShouldCreateNewItem`
  - `GetData_ShouldReturnItems`

- **UI Tests**: `UiTests/VerifyItemUiTests.cs`
  - `CreatedItem_ShouldBeVisibleInUI`

### Key Assertions
- **API Tests**:
  - Verify POST response contains `name` and `id`
  - Verify GET response is an array and contains items

- **UI Tests**:
  - Verify created item is visible in UI
  - Assert item name matches
  - Highlight item and capture screenshot

### Screenshot
- Full-page screenshot captured and attached in UI test