### PR TITLE
[TestGen] Add API and UI tests for data endpoints

### DIFF
--- a/ApiTests/DataApiTests.cs
+++ b/ApiTests/DataApiTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace ApiTests
+{
+    public class DataApiTests : UiTestBase
+    {
+        [Test]
+        public async Task PostData_ShouldCreateNewItem()
+        {
+            // Arrange
+            var payload = new DataItem
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Optional description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty), "Response does not contain 'name'");
+            Assert.AreEqual(payload.Name, nameProperty.GetString(), "The name of the created item does not match");
+
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+
+        [Test]
+        public async Task GetData_ShouldReturnDataArray()
+        {
+            // Act
+            var response = await API.GetAsync("/api/data");
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty");
+
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+    }
+}

--- a/UiTests/DataUiTests.cs
+++ b/UiTests/DataUiTests.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace UiTests
+{
+    public class DataUiTests : UiTestBase
+    {
+        [Test]
+        public async Task CreatedItem_ShouldBeVisibleInUI()
+        {
+            // Arrange
+            var payload = new DataItem
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Optional description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id'");
+            var itemId = idProperty.GetInt32();
+
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            // Act
+            await Page.GotoAsync("http://localhost:5000");
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            var item = await Page.QuerySelectorAsync(itemSelector);
+
+            // Assert
+            Assert.IsNotNull(item, $"Item with ID {itemId} not found in UI");
+            var itemName = await item.EvalOnSelectorAsync<string>("strong", "el => el.innerText");
+            Assert.AreEqual(payload.Name, itemName, "The name of the created item does not match");
+
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+
+            var screenshotPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.WriteLine($"📸 Screenshot saved at: {screenshotPath}");
+            TestContext.WriteLine("✅ UI verification successful.");
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}


### PR DESCRIPTION
### Added Tests

- **API Tests**: 
  - `ApiTests/DataApiTests.cs`: Tests for `POST /api/data` and `GET /api/data` endpoints.
    - Verifies that a new item can be created and the response contains the correct data.
    - Verifies that the `GET /api/data` endpoint returns an array of data.

- **UI Test**: 
  - `UiTests/DataUiTests.cs`: Tests that a created item is visible in the UI.
    - Verifies that the item appears in the UI after being created via the API.
    - Highlights the item and captures a screenshot for verification.

### Key Assertions
- API response contains `id` and `name` properties.
- UI contains the created item with the correct name.
- Screenshot is captured and attached for UI verification.

### Screenshot Info
- Full-page screenshot is captured after verifying the item in the UI and is attached to the test context.