### PR TITLE
[TestGen] Add API and UI tests for verifyitem

### DIFF
--- a/ApiTests/GetDataTests.cs
+++ b/ApiTests/GetDataTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using TestBase;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class GetDataTests : UiTestBase
+    {
+        [Test]
+        public async Task GetData_ShouldReturnDataArray()
+        {
+            // Arrange
+            // No arrangement needed for GET request
+
+            // Act
+            var response = await API.GetAsync("/api/data");
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+            Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array.");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty.");
+        }
+    }
+}

--- a/ApiTests/PostDataTests.cs
+++ b/ApiTests/PostDataTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class PostDataTests : UiTestBase
+    {
+        [Test]
+        public async Task PostData_ShouldReturnCreatedItem()
+        {
+            // Arrange
+            var payload = new {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Optional description"
+            };
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProperty), "Response does not contain 'name' property.");
+            Assert.AreEqual(payload.Name, nameProperty.GetString(), "Item name does not match.");
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProperty), "Response does not contain 'id' property.");
+            Assert.Greater(idProperty.GetInt32(), 0, "Item ID is not valid.");
+        }
+    }
+}

--- a/UiTests/VerifyItemVisibilityTests.cs
+++ b/UiTests/VerifyItemVisibilityTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+
+namespace UiTests
+{
+    [TestFixture]
+    public class VerifyItemVisibilityTests : UiTestBase
+    {
+        [Test]
+        public async Task CreatedItem_ShouldBeVisibleInUI()
+        {
+            // Arrange
+            var payload = new {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Optional description"
+            };
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+            var itemId = responseBody.GetProperty("id").GetInt32();
+            var itemName = responseBody.GetProperty("name").GetString();
+
+            // Act
+            await Page.GotoAsync("http://localhost:5000");
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            TestContext.WriteLine($"🔍 Verifying item with selector: {itemSelector}");
+            var itemElement = await Page.QuerySelectorAsync(itemSelector);
+
+            // Assert
+            Assert.NotNull(itemElement, "Item element not found in UI.");
+            var isVisible = await itemElement.IsVisibleAsync();
+            Assert.IsTrue(isVisible, "Item element is not visible.");
+            var itemNameElement = await itemElement.QuerySelectorAsync("strong");
+            var itemNameText = await itemNameElement.InnerTextAsync();
+            Assert.AreEqual(itemName, itemNameText, "Item name does not match.");
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+            var screenshotPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.WriteLine($"📸 Screenshot saved at: {screenshotPath}");
+            TestContext.WriteLine("✅ UI verification successful.");
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}


### PR DESCRIPTION
### Added Tests

- **API Tests**:
  - `ApiTests/PostDataTests.cs`: Verifies POST /api/data endpoint.
  - `ApiTests/GetDataTests.cs`: Verifies GET /api/data endpoint.
- **UI Tests**:
  - `UiTests/VerifyItemVisibilityTests.cs`: Verifies created item is visible in the UI.

### Key Assertions
- **API Tests**:
  - Assert response contains `name` and `id` properties.
  - Assert response array is not empty.
- **UI Tests**:
  - Assert item element is visible.
  - Assert item name matches.
  - Highlight item and capture full-page screenshot.

### Screenshot
- Full-page screenshot is captured and attached for UI verification.