### PR TITLE
[TestGen] Add API and UI tests for verifyitem

### DIFF
--- a/ApiTests/DataApiTests.cs
+++ b/ApiTests/DataApiTests.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class DataApiTests : UiTestBase
+    {
+        [Test]
+        public async Task PostData_ShouldReturnCreatedItem()
+        {
+            // Arrange
+            var payload = new DataItem
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Test Description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            response.EnsureSuccessStatusCode();
+
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            // Assert
+            Assert.IsTrue(responseBody.TryGetProperty("name", out var nameProp), "Response JSON does not contain 'name' property.");
+            Assert.AreEqual(payload.Name, nameProp.GetString(), "The 'name' property does not match the payload.");
+
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProp), "Response JSON does not contain 'id' property.");
+            Assert.Greater(idProp.GetInt32(), 0, "The 'id' property is not a positive integer.");
+        }
+
+        [Test]
+        public async Task GetData_ShouldReturnDataArray()
+        {
+            // Act
+            var response = await API.GetAsync("/api/data");
+            response.EnsureSuccessStatusCode();
+
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            // Assert
+            Assert.AreEqual(JsonValueKind.Array, responseBody.ValueKind, "Response JSON is not an array.");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response JSON array is empty.");
+        }
+    }
+}

--- a/UiTests/VerifyItemUiTests.cs
+++ b/UiTests/VerifyItemUiTests.cs
@@ -1,0 +1,75 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace UiTests
+{
+    [TestFixture]
+    public class VerifyItemUiTests : UiTestBase
+    {
+        [Test]
+        public async Task CreatedItem_ShouldBeVisibleInUI()
+        {
+            // Arrange
+            var payload = new DataItem
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "Test Description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            response.EnsureSuccessStatusCode();
+
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            // Extract ID from response
+            Assert.IsTrue(responseBody.TryGetProperty("id", out var idProp), "Response JSON does not contain 'id' property.");
+            var itemId = idProp.GetInt32();
+
+            // Navigate to UI
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+            await Page.GotoAsync("http://localhost:5000");
+
+            // Assert item is visible in UI
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            TestContext.WriteLine($"🔍 Verifying item with selector: {itemSelector}");
+            var itemElement = await Page.QuerySelectorAsync(itemSelector);
+            Assert.IsNotNull(itemElement, "Item not found in UI.");
+
+            var itemName = await itemElement.EvalOnSelectorAsync<string>("strong", "el => el.textContent");
+            Assert.AreEqual(payload.Name, itemName, "The item name in the UI does not match the payload.");
+
+            // Highlight the item
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+
+            // Capture screenshot
+            var screenshotPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.WriteLine($"📸 Screenshot saved at: {screenshotPath}");
+            TestContext.WriteLine("✅ UI verification successful.");
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+    }
+}


### PR DESCRIPTION
### Added Tests

- **API Tests**: 
  - `ApiTests/DataApiTests.cs`
    - `PostData_ShouldReturnCreatedItem`: Verifies that the POST /api/data endpoint creates an item and returns the correct response.
    - `GetData_ShouldReturnDataArray`: Verifies that the GET /api/data endpoint returns an array of data.

- **UI Test**:
  - `UiTests/VerifyItemUiTests.cs`
    - `CreatedItem_ShouldBeVisibleInUI`: Verifies that an item created via the API is visible in the UI and matches the expected name.

### Key Assertions
- API tests ensure the response JSON contains the expected properties and values.
- UI test verifies the visibility of the created item and matches the item name.
- UI test captures a screenshot and attaches it for visual verification.

### Screenshot Info
- Full-page screenshot is captured at the end of the UI test and attached to the test context for review.